### PR TITLE
Add Babel to transpile to es5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "latest"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ test:
 	echo "TODO test app"
 
 build: clean
-	@cp -r src dist
-	@echo '✓ Copy /src to /dist'
+	@npm run-script build
+	@echo '✓ Transpile to es5, output to dist'
 
 clean:
 	@rm -rf dist

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "./node_modules/.bin/babel src -d dist"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,8 @@
     "opentracing": "^0.11.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-preset-latest": "^6.16.0",
     "sinon": "^1.17.6"
   }
 }


### PR DESCRIPTION
Babel is standard practice to make es2015+ javascript compatible with
repositories and environments that do not support these language
features.