### PR TITLE
Use route path for opName instead of url path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # dependencies
 node_modules
+
+# generated files
+dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing-middleware",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "opentracing middleware for express-js",
   "main": "dist/index.js",
   "publishConfig": {


### PR DESCRIPTION
This allows us to aggregate traces for the same route handler and makes it somewhat consistent with WAG which uses `operationID` as the name.

Tested:
Ran locally in the launchpad and verified that spans get the route matcher as the operation name.
https://app.lightstep.com/clever_dev/trace?span_guid=0981cd690c667f6a&at_micros=1481829646407598#span-0981cd690c667f6a