### PR TITLE
revert opentracing upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
 # tracing-middleware
 
-Middleware for express to enable opentracing. Configured for Lightstep, but supports any opentracing implementation.
+Middleware for express to enable opentracing.
+Supports any opentracing tracer compatible with version 0.11.0 of the opentracing javascript library.
 
 ## Install
 ```
-npm install --save "tracing-middleware"
+npm install --save tracing-middleware
 ```
 
 ## Usage
+
+E.g., using LightStep as your tracer:
+
 ```
 import * as express from "express";
 import middleware from "tracing-middleware";
+import * as LightStep from "lightstep-tracer";
+
+const lsTracer = LightStep.tracer({
+  access_token   : 'foo',
+  component_name : 'bar',
+});
 
 const app = express();
-const LIGHTSTEP_ACCESS_TOKEN = "access_token";
-app.use(middleware({access_token: LIGHTSTEP_ACCESS_TOKEN}));
+app.use(middleware({tracer: lsTracer}));
 ```
 
 ## Options
 The `middleware` function takes in an options object as its only argument.
 ```
 const options = {
-  tracer: {}, // Override the tracer used in this middleware with your own custom tracing implementation
-  access_token: "Lightstep access token", // Creates a lightstep tracer if provided
+  tracer: [Tracer], // Defaults to the opentracing no-op tracer.
 }
 ```
-If neither `tracer` nor `access_token` is provided (e.g. `app.use(middleware())`), then the default opentracing library is used.

--- a/package.json
+++ b/package.json
@@ -26,16 +26,19 @@
   },
   "homepage": "https://github.com/Clever/tracing-middleware#readme",
   "dependencies": {
-    "lightstep-tracer": "^0.11.20",
-    "opentracing": "^0.13.0"
+    "opentracing": "^0.11.0"
+  },
+  "peerDependencies": {
+    "opentracing": "^0.11.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-latest": "^6.16.0",
     "express": "3.x.x",
+    "lightstep-tracer": "^0.11.20",
     "mocha": "^3.2.0",
     "request": "^2.79.0",
-    "sinon": "^1.17.6",
+    "sinon": "^1.17.7",
     "underscore": "^1.8.3"
   }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,24 +1,15 @@
-import lightstep from "lightstep-tracer";
-import opentracing from "opentracing";
+import tracer from "opentracing";
 import * as url from "url";
 
 export default function middleware(options = {}) {
-  let tracer = null;
   if (options.tracer) {
-    tracer = options.tracer;
-  } else if (options.access_token) {
-    // default to lightstep if no tracer is given but access_token is provided
-    tracer = lightstep.tracer({
-      access_token: options.access_token,
-      component_name: options.source,
-    });
+    tracer.initGlobalTracer(options.tracer);
   } else {
-    tracer = opentracing.Tracer();
+    tracer.initGlobalTracer();
   }
-  opentracing.initGlobalTracer(tracer);
 
   return (req, res, next) => {
-    const wireCtx = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, req.headers);
+    const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
     const pathname = url.parse(req.url).pathname;
     const span = tracer.startSpan(pathname, {childOf: wireCtx});
     span.logEvent("request_received");
@@ -31,7 +22,7 @@ export default function middleware(options = {}) {
     // include trace ID in headers so that we can debug slow requests we see in
     // the browser by looking up the trace ID found in response headers
     const responseHeaders = {};
-    tracer.inject(span.context(), opentracing.FORMAT_TEXT_MAP, responseHeaders);
+    tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
     Object.keys(responseHeaders).forEach(key => res.setHeader(key, responseHeaders[key]));
 
     // add the span to the request object for handlers to use

--- a/test/server.js
+++ b/test/server.js
@@ -1,19 +1,63 @@
 const assert = require("assert");
 const opentracing = require("opentracing");
-const {MockTracer} = require("opentracing/lib/mock_tracer");
 const express = require("express");
 const middleware = require("../dist/index.js").default;
 const request = require("request");
+const LightStep = require("lightstep-tracer");
+const sinon = require("sinon");
 
 describe("e2e express app", () => {
-  it("works", (done) => {
-    // create and start an express server, hit it with a request
-    const mockTracer = new MockTracer();
-    const noopTracer = new opentracing.Tracer();
-    mockTracer._extract = noopTracer._extract;
-    mockTracer._inject = noopTracer._inject;
+  it("works with default tracer", (done) => {
     const app = express();
-    app.use(middleware({tracer: mockTracer}));
+    app.use(middleware({}));
+    const startSpanSpy = sinon.spy(opentracing, "startSpan");
+
+    let reqSpanPresent = false;
+    app.get("/", (req, res) => {
+      if (req.span) {
+        reqSpanPresent = true;
+      }
+      res.send("Hello World!")
+    });
+
+    const server = app.listen(3000, (err) => {
+      const opts = {
+        url : "http://localhost:3000/",
+        method: "GET",
+      };
+      request(opts, (err, res, body) => {
+        assert.ifError(err);
+        assert.equal(res.statusCode, 200, body);
+        assert(reqSpanPresent, "expected req.span to be set");
+        assert(startSpanSpy.calledOnce, "expected only one span");
+        // TODO: once lightstep supports opentracing 0.13.0, we can use
+        // mocktracer and verify some more details on the span itself
+        //const span = mockTracer._spans[0];
+        //assert.deepEqual(span._tags, {
+        //  "http.method": "GET",
+        //  "span.kind": "server",
+        //  "http.url": "/",
+        //  "http.status_code": 200,
+        //});
+        //assert.equal(span._operationName, "/");
+        //assert.equal(span._logs.length, 2, "expected two logs in the span");
+        //const [startLog, finishLog] = span._logs;
+        //assert.equal(startLog.fields.event, "request_received");
+        //assert.equal(finishLog.fields.event, "request_finished");
+        server.close();
+        done();
+      });
+    });
+  });
+
+
+  it("works with latest lightstep tracer", (done) => {
+    const lsTracer = LightStep.tracer({
+      access_token   : 'foo',
+      component_name : 'bar',
+    });
+    const app = express();
+    app.use(middleware({tracer: lsTracer}));
 
     var reqSpanPresent = false;
     app.get("/", (req, res) => {
@@ -32,19 +76,6 @@ describe("e2e express app", () => {
         assert.ifError(err);
         assert.equal(res.statusCode, 200, body);
         assert(reqSpanPresent, "expected req.span to be set");
-        assert.equal(mockTracer._spans.length, 1, "expected only one span");
-        const span = mockTracer._spans[0];
-        assert.deepEqual(span._tags, {
-          "http.method": "GET",
-          "span.kind": "server",
-          "http.url": "/",
-          "http.status_code": 200,
-        });
-        assert.equal(span._operationName, "/");
-        assert.equal(span._logs.length, 2, "expected two logs in the span");
-        const [startLog, finishLog] = span._logs;
-        assert.equal(startLog.fields.event, "request_received");
-        assert.equal(finishLog.fields.event, "request_finished");
         server.close();
         done();
       });


### PR DESCRIPTION
#8 introduced a bug:

- opentracing 0.13.0 requires your tracer implementation to supply `inject` and `extract` methods
- the latest version of the lightstep js tracer does not have these methods

Thus, when you went to use this middleware with lightstep as your tracer, all sorts of things blew up.

What I've done to rectify this:
- I unpublished 0.1.7 of this library
- I added a test that tries to use the middleware with the latest lightstep tracer (and reproduces the blow up)
- I downgraded back to opentracing 0.11.0, which is what lightstep tests against, and which fixes the blow up. Downgrading to 0.11.0 also requires mostly reverting #8
- I made opentracing at 0.11.0 a peer dependency, which should be another way to warn about this incompatibility

I've also removed this library's dependency on lightstep, which is a breaking change to the initialization API, but I think is for the best.

Rollout plan is to test this some more locally, then publish 0.2.0.