### PR TITLE
Update to work with opentracing 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing-middleware",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "opentracing middleware for express-js",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   },
   "homepage": "https://github.com/Clever/tracing-middleware#readme",
   "dependencies": {
-    "opentracing": "^0.11.0"
+    "opentracing": "^0.14.0"
   },
   "peerDependencies": {
-    "opentracing": "^0.11.0"
+    "opentracing": "^0.14.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-latest": "^6.16.0",
-    "express": "3.x.x",
-    "lightstep-tracer": "^0.11.20",
+    "express": "4.x.x",
+    "lightstep-tracer": "^0.20.3",
     "mocha": "^3.2.0",
     "request": "^2.79.0",
     "sinon": "^1.17.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tracing-middleware",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "opentracing middleware for express-js",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,14 +2,9 @@ import * as opentracing from "opentracing";
 import * as url from "url";
 
 export default function middleware(options = {}) {
-  if (options.tracer) {
-    opentracing.initGlobalTracer(options.tracer);
-  } else {
-    opentracing.initGlobalTracer();
-  }
+  const tracer = options.tracer || opentracing.globalTracer();
 
   return (req, res, next) => {
-    const tracer = opentracing.globalTracer();
     const wireCtx = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, req.headers);
     const pathname = url.parse(req.url).pathname;
     const span = tracer.startSpan(pathname, {childOf: wireCtx});

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,15 +1,16 @@
-import tracer from "opentracing";
+import * as opentracing from "opentracing";
 import * as url from "url";
 
 export default function middleware(options = {}) {
   if (options.tracer) {
-    tracer.initGlobalTracer(options.tracer);
+    opentracing.initGlobalTracer(options.tracer);
   } else {
-    tracer.initGlobalTracer();
+    opentracing.initGlobalTracer();
   }
 
   return (req, res, next) => {
-    const wireCtx = tracer.extract(tracer.FORMAT_HTTP_HEADERS, req.headers);
+    const tracer = opentracing.globalTracer();
+    const wireCtx = tracer.extract(opentracing.FORMAT_HTTP_HEADERS, req.headers);
     const pathname = url.parse(req.url).pathname;
     const span = tracer.startSpan(pathname, {childOf: wireCtx});
     span.logEvent("request_received");
@@ -22,7 +23,7 @@ export default function middleware(options = {}) {
     // include trace ID in headers so that we can debug slow requests we see in
     // the browser by looking up the trace ID found in response headers
     const responseHeaders = {};
-    tracer.inject(span, tracer.FORMAT_TEXT_MAP, responseHeaders);
+    tracer.inject(span, opentracing.FORMAT_TEXT_MAP, responseHeaders);
     Object.keys(responseHeaders).forEach(key => res.setHeader(key, responseHeaders[key]));
 
     // add the span to the request object for handlers to use

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,7 +30,8 @@ export default function middleware(options = {}) {
     Object.assign(req, {span});
 
     // finalize the span when the response is completed
-    res.on("finish", () => {
+    const endCopy = res.end;
+    res.end = function() {
       span.logEvent("request_finished");
       // Route matching often happens after the middleware is run. Try changing the operation name
       // to the route matcher.
@@ -42,7 +43,8 @@ export default function middleware(options = {}) {
         span.setTag("sampling.priority", 1);
       }
       span.finish();
-    });
+      endCopy.apply(this, arguments);
+    };
     next();
   };
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -25,8 +25,7 @@ export default function middleware(options = {}) {
     Object.assign(req, {span});
 
     // finalize the span when the response is completed
-    const endCopy = res.end;
-    res.end = function() {
+    const finishSpan = () => {
       span.logEvent("request_finished");
       // Route matching often happens after the middleware is run. Try changing the operation name
       // to the route matcher.
@@ -38,8 +37,10 @@ export default function middleware(options = {}) {
         span.setTag("sampling.priority", 1);
       }
       span.finish();
-      endCopy.apply(this, arguments);
     };
+    res.on('close', finishSpan);
+    res.on('finish', finishSpan);
+
     next();
   };
 }

--- a/test/server.js
+++ b/test/server.js
@@ -9,8 +9,9 @@ const sinon = require("sinon");
 describe("e2e express app", () => {
   it("works with default tracer", (done) => {
     const app = express();
-    app.use(middleware({}));
-    const startSpanSpy = sinon.spy(opentracing, "startSpan");
+    const tracer = new opentracing.Tracer()
+    app.use(middleware({ tracer }));
+    const startSpanSpy = sinon.spy(tracer, "startSpan");
 
     let reqSpanPresent = false;
     app.get("/", (req, res) => {
@@ -83,7 +84,7 @@ describe("e2e express app", () => {
   });
 
   it("works with latest lightstep tracer", (done) => {
-    const lsTracer = LightStep.tracer({
+    const lsTracer = new LightStep.Tracer({
       access_token   : 'foo',
       component_name : 'bar',
     });

--- a/test/server.js
+++ b/test/server.js
@@ -9,8 +9,8 @@ const sinon = require("sinon");
 describe("e2e express app", () => {
   it("works with default tracer", (done) => {
     const app = express();
-    const tracer = new opentracing.Tracer()
-    app.use(middleware({ tracer }));
+    const tracer = opentracing.globalTracer();
+    app.use(middleware({}));
     const startSpanSpy = sinon.spy(tracer, "startSpan");
 
     let reqSpanPresent = false;


### PR DESCRIPTION
* Update the library to work with API changes made in opentracing 0.14.0.
* Changes the span finalization to override the end function so that it can work in cases where the finish event isn't emitted. (See comments in this SO [thread](http://stackoverflow.com/questions/11335278/how-to-have-a-nodejs-connect-middleware-execute-after-responde-end-has-been-in)).
* Don't call the initGlobalTracer method. That method should only be called [once](https://github.com/opentracing/opentracing-javascript/blob/master/src/global_tracer.ts#L40). Calling it in the middleware could interfere with code that initializes it elsewhere.

Btw would you be ok with moving this project to a repository under https://github.com/opentracing-contrib?